### PR TITLE
Use root namespace prefix

### DIFF
--- a/classes/optimus.php
+++ b/classes/optimus.php
@@ -106,7 +106,7 @@ class Optimus {
 
         // error catching
         if (!empty($curlError) || empty($body)) {
-            throw new Exception("Optimus-Error: {$curlError}, Output: {$body}");
+            throw new \Exception("Optimus-Error: {$curlError}, Output: {$body}");
         }
 
         return $body;


### PR DESCRIPTION
There is no Grav\Plugin\Exception class

As example:

`[2016-11-15 01:49:43] grav.CRITICAL: Class 'Grav\Plugin\Exception' not found - Trace: #0 /somepath/grav/vendor/filp/whoops/src/Whoops/Run.php(375): Whoops\Run->handleError(1, 'Class 'Grav\\Plu...', '/somepath...', 109) #1 [internal function]: Whoops\Run->handleShutdown() #2 {main}`